### PR TITLE
Add deprecation error level processor for Monolog

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,7 @@
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"
     failOnNotice="true"
+    failOnDeprecation="true"
     failOnWarning="true"
     failOnPhpunitNotice="true"
     cacheDirectory="var/phpunit-cache"

--- a/src/Monolog/DeprecationErrorLevelProcessor.php
+++ b/src/Monolog/DeprecationErrorLevelProcessor.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Etrias\PhpToolkit\Monolog;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('monolog.processor', ['channel' => 'deprecation'])]
+final class DeprecationErrorLevelProcessor implements ProcessorInterface
+{
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        if ($record->level->isLowerThan(Level::Error)) {
+            return $record->with(level: Level::Error);
+        }
+
+        return $record;
+    }
+}

--- a/src/Monolog/Processor/DeprecationErrorLevelProcessor.php
+++ b/src/Monolog/Processor/DeprecationErrorLevelProcessor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Etrias\PhpToolkit\Monolog;
+namespace Etrias\PhpToolkit\Monolog\Processor;
 
 use Monolog\Level;
 use Monolog\LogRecord;


### PR DESCRIPTION
## Summary
This PR introduces a new Monolog processor that automatically elevates deprecation warnings to error level, and enables strict deprecation handling in PHPUnit configuration.

## Key Changes
- **New `DeprecationErrorLevelProcessor` class**: A Monolog processor that intercepts log records on the `deprecation` channel and ensures they are logged at `Error` level or higher. Records below error level are automatically upgraded to `Error` level.
- **PHPUnit strict mode**: Added `failOnDeprecation="true"` to PHPUnit configuration to fail tests when deprecations are encountered, promoting stricter code quality standards.

## Implementation Details
- The processor is auto-configured via the `#[AutoconfigureTag]` attribute with the `monolog.processor` tag, targeting the `deprecation` channel specifically
- Uses Monolog's `Level::isLowerThan()` method for comparison and `LogRecord::with()` for immutable record updates
- Follows strict typing and modern PHP practices (PHP 8.1+ attributes)

https://claude.ai/code/session_01KmgynDJ3fsg21z7grFqkgY