### PR TITLE
chore: remove docker compose --quiet-pull flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MAKEFLAGS += --warn-undefined-variables --always-make --output-sync=target
 CI ?= false
 
 compose=docker compose
-run=${compose} run --quiet-pull --rm
+run=${compose} run --rm
 run_app=${run} --no-deps php
 run_app_deps=${run} php
 


### PR DESCRIPTION
## Summary
Removed the `--quiet-pull` flag from the docker compose run command in the Makefile to simplify the build configuration.

## Changes
- Removed `--quiet-pull` flag from the `run` variable definition in the Makefile
- The docker compose run command now uses only the `--rm` flag for cleanup

## Details
The `--quiet-pull` flag suppressed pull progress output during docker image pulls. This change allows standard pull progress information to be displayed during builds, which can be useful for visibility into the build process and debugging potential image pull issues.

https://claude.ai/code/session_014Lzxt1vZgYxnJDoZvwWbnr