### PR TITLE
Fix ReflectionObject instantiation syntax in GuzzleClientFactory

### DIFF
--- a/src/Http/GuzzleClientFactory.php
+++ b/src/Http/GuzzleClientFactory.php
@@ -24,7 +24,7 @@ final class GuzzleClientFactory
             $handler = new HandlerStack(static function (RequestInterface $request) use ($client): PromiseInterface {
                 $promise = $client->sendAsyncRequest($request);
 
-                return new \ReflectionObject($promise)->getProperty('promise')->getValue($promise);
+                return (new \ReflectionObject($promise))->getProperty('promise')->getValue($promise);
             });
         } else {
             $handler = new HandlerStack(static fn (RequestInterface $request): PromiseInterface => new FulfilledPromise($client->sendRequest($request)));


### PR DESCRIPTION
## Summary
This PR fixes a minor code style issue in the `GuzzleClientFactory` class where a `ReflectionObject` instantiation was not properly wrapped in parentheses before calling the `getProperty()` method.

## Changes
- Wrapped `new \ReflectionObject($promise)` in parentheses before method chaining to ensure proper instantiation and method call syntax

## Details
The change improves code clarity by explicitly grouping the object instantiation with parentheses before calling instance methods. While both syntaxes are functionally equivalent in PHP, the corrected version follows better coding practices and is more readable.

https://claude.ai/code/session_018QmB1euuQQRJR8Ux1oSfDS