### PR TITLE
chore: Add commit message to auto-commit workflow step

### DIFF
--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -61,6 +61,7 @@ jobs:
             -
                 uses: stefanzweifel/git-auto-commit-action@v7.1.0
                 with:
+                    commit_message: '[no ci] Apply automatic changes'
                     commit_user_name: etrias
                     commit_user_email: etrias@users.noreply.github.com
                     commit_author: etrias <etrias@users.noreply.github.com>


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to explicitly set a commit message for the automatic code changes step.

## Key Changes
- Added `commit_message: '[no ci] Apply automatic changes'` to the git-auto-commit-action configuration
- This ensures that automated commits are properly labeled with the `[no ci]` directive to prevent triggering additional CI runs

## Implementation Details
The commit message includes the `[no ci]` prefix, which signals to GitHub that these automated changes should not trigger subsequent workflow runs, preventing unnecessary CI cycles and potential infinite loops from automatic formatting or linting corrections.

https://claude.ai/code/session_01PDoVgDz2riaSuRyn1CRLUk