### PR TITLE
fix: never cache an empty or malformed WSDL

### DIFF
--- a/src/Soap/CachedWsdlProvider.php
+++ b/src/Soap/CachedWsdlProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Etrias\PhpToolkit\Soap;
 
 use Soap\ExtSoapEngine\Wsdl\WsdlProvider;
+use Soap\Wsdl\Exception\UnloadableWsdlException;
 use Soap\Wsdl\Loader\WsdlLoader;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -27,9 +28,36 @@ final class CachedWsdlProvider implements WsdlProvider
         $cacheFile = $this->cacheDir.'/'.md5($location).'.wsdl';
 
         if (!$this->filesystem->exists($cacheFile) || $this->test) {
-            $this->filesystem->dumpFile($cacheFile, ($this->loader)($location));
+            $wsdl = ($this->loader)($location);
+
+            // Never cache an empty or malformed WSDL: the cache file has no TTL and is only
+            // refetched when missing, so a bad response (e.g. an upstream 404) would otherwise
+            // be served on every call until the cache is cleared by hand.
+            if ('' === trim($wsdl)) {
+                throw UnloadableWsdlException::noContentAt($location);
+            }
+            if (!$this->isWellFormedWsdl($wsdl)) {
+                throw UnloadableWsdlException::fromLocation($location);
+            }
+
+            $this->filesystem->dumpFile($cacheFile, $wsdl);
         }
 
         return $cacheFile;
+    }
+
+    private function isWellFormedWsdl(string $wsdl): bool
+    {
+        $useInternalErrors = libxml_use_internal_errors(true);
+
+        try {
+            $document = new \DOMDocument();
+            $rootElement = $document->loadXML($wsdl, LIBXML_NONET) ? $document->documentElement?->localName : null;
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($useInternalErrors);
+        }
+
+        return 'definitions' === $rootElement || 'description' === $rootElement;
     }
 }

--- a/src/Soap/CachedWsdlProvider.php
+++ b/src/Soap/CachedWsdlProvider.php
@@ -48,6 +48,10 @@ final class CachedWsdlProvider implements WsdlProvider
 
     private function isWellFormedWsdl(string $wsdl): bool
     {
+        if ('' === $wsdl) {
+            return false;
+        }
+
         $useInternalErrors = libxml_use_internal_errors(true);
 
         try {

--- a/tests/Soap/CachedWsdlProviderTest.php
+++ b/tests/Soap/CachedWsdlProviderTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Etrias\PhpToolkit\Tests\Soap;
+
+use Etrias\PhpToolkit\Soap\CachedWsdlProvider;
+use PHPUnit\Framework\TestCase;
+use Soap\Wsdl\Exception\UnloadableWsdlException;
+use Soap\Wsdl\Loader\WsdlLoader;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class CachedWsdlProviderTest extends TestCase
+{
+    private const string VALID_WSDL = <<<'XML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" name="Test">
+            <wsdl:service name="Test"/>
+        </wsdl:definitions>
+        XML;
+
+    private Filesystem $filesystem;
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->cacheDir = sys_get_temp_dir().'/php-toolkit-wsdl-test-'.bin2hex(random_bytes(6));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->cacheDir);
+    }
+
+    public function testCachesValidWsdlOnce(): void
+    {
+        $loader = new class(self::VALID_WSDL) implements WsdlLoader {
+            public int $calls = 0;
+
+            public function __construct(private readonly string $wsdl) {}
+
+            public function __invoke(string $location): string
+            {
+                ++$this->calls;
+
+                return $this->wsdl;
+            }
+        };
+
+        $provider = new CachedWsdlProvider($loader, $this->filesystem, $this->cacheDir, false);
+        $location = 'https://example.test/service.wsdl';
+
+        $file = $provider($location);
+
+        self::assertFileExists($file);
+        self::assertStringContainsString('definitions', (string) file_get_contents($file));
+        self::assertSame(1, $loader->calls);
+
+        self::assertSame($file, $provider($location));
+        self::assertSame(1, $loader->calls, 'A cached WSDL must not be reloaded.');
+    }
+
+    public function testDoesNotCacheEmptyWsdl(): void
+    {
+        $provider = new CachedWsdlProvider($this->loader(''), $this->filesystem, $this->cacheDir, false);
+
+        try {
+            $provider('https://example.test/service.wsdl');
+            self::fail('Expected an UnloadableWsdlException.');
+        } catch (UnloadableWsdlException) {
+        }
+
+        self::assertSame([], glob($this->cacheDir.'/*.wsdl') ?: []);
+    }
+
+    public function testDoesNotCacheMalformedWsdl(): void
+    {
+        $provider = new CachedWsdlProvider($this->loader('<html><body>404 Not Found</body></html>'), $this->filesystem, $this->cacheDir, false);
+
+        try {
+            $provider('https://example.test/service.wsdl');
+            self::fail('Expected an UnloadableWsdlException.');
+        } catch (UnloadableWsdlException) {
+        }
+
+        self::assertSame([], glob($this->cacheDir.'/*.wsdl') ?: []);
+    }
+
+    private function loader(string $wsdl): WsdlLoader
+    {
+        return new class($wsdl) implements WsdlLoader {
+            public function __construct(private readonly string $wsdl) {}
+
+            public function __invoke(string $location): string
+            {
+                return $this->wsdl;
+            }
+        };
+    }
+}

--- a/tests/Soap/CachedWsdlProviderTest.php
+++ b/tests/Soap/CachedWsdlProviderTest.php
@@ -22,18 +22,18 @@ final class CachedWsdlProviderTest extends TestCase
         </wsdl:definitions>
         XML;
 
-    private Filesystem $filesystem;
-    private string $cacheDir;
+    private const string LOCATION = 'https://example.test/service.wsdl';
+
+    private string $cacheDir = '';
 
     protected function setUp(): void
     {
-        $this->filesystem = new Filesystem();
         $this->cacheDir = sys_get_temp_dir().'/php-toolkit-wsdl-test-'.bin2hex(random_bytes(6));
     }
 
     protected function tearDown(): void
     {
-        $this->filesystem->remove($this->cacheDir);
+        (new Filesystem())->remove($this->cacheDir);
     }
 
     public function testCachesValidWsdlOnce(): void
@@ -51,43 +51,41 @@ final class CachedWsdlProviderTest extends TestCase
             }
         };
 
-        $provider = new CachedWsdlProvider($loader, $this->filesystem, $this->cacheDir, false);
-        $location = 'https://example.test/service.wsdl';
+        $provider = new CachedWsdlProvider($loader, new Filesystem(), $this->cacheDir, false);
 
-        $file = $provider($location);
+        $file = $provider(self::LOCATION);
 
         self::assertFileExists($file);
         self::assertStringContainsString('definitions', (string) file_get_contents($file));
-        self::assertSame(1, $loader->calls);
 
-        self::assertSame($file, $provider($location));
-        self::assertSame(1, $loader->calls, 'A cached WSDL must not be reloaded.');
+        self::assertSame($file, $provider(self::LOCATION));
+        self::assertSame(1, $loader->calls, 'A cached WSDL must be loaded only once.');
     }
 
     public function testDoesNotCacheEmptyWsdl(): void
     {
-        $provider = new CachedWsdlProvider($this->loader(''), $this->filesystem, $this->cacheDir, false);
+        $provider = new CachedWsdlProvider($this->loader(''), new Filesystem(), $this->cacheDir, false);
 
         try {
-            $provider('https://example.test/service.wsdl');
+            $provider(self::LOCATION);
             self::fail('Expected an UnloadableWsdlException.');
         } catch (UnloadableWsdlException) {
         }
 
-        self::assertSame([], glob($this->cacheDir.'/*.wsdl') ?: []);
+        self::assertFileDoesNotExist($this->cacheDir.'/'.md5(self::LOCATION).'.wsdl');
     }
 
     public function testDoesNotCacheMalformedWsdl(): void
     {
-        $provider = new CachedWsdlProvider($this->loader('<html><body>404 Not Found</body></html>'), $this->filesystem, $this->cacheDir, false);
+        $provider = new CachedWsdlProvider($this->loader('<html><body>404 Not Found</body></html>'), new Filesystem(), $this->cacheDir, false);
 
         try {
-            $provider('https://example.test/service.wsdl');
+            $provider(self::LOCATION);
             self::fail('Expected an UnloadableWsdlException.');
         } catch (UnloadableWsdlException) {
         }
 
-        self::assertSame([], glob($this->cacheDir.'/*.wsdl') ?: []);
+        self::assertFileDoesNotExist($this->cacheDir.'/'.md5(self::LOCATION).'.wsdl');
     }
 
     private function loader(string $wsdl): WsdlLoader


### PR DESCRIPTION
## What & why

`CachedWsdlProvider` writes whatever the `WsdlLoader` returns to a cache file that has **no TTL** and is only refetched when the file is missing:

```php
if (!$this->filesystem->exists($cacheFile) || $this->test) {
    $this->filesystem->dumpFile($cacheFile, ($this->loader)($location));
}
```

The PSR-18 loader (`Soap\Psr18Transport\Wsdl\Psr18Loader`) returns `(string) $response->getBody()` **without checking the HTTP status**. So when an upstream WSDL endpoint returns an empty or error body, that empty string gets cached and is then served on every call forever — the SOAP client fails with `SOAP-ERROR: Parsing WSDL … Document is empty` until someone clears `var/cache` by hand.

This actually happened in `shipping-api`: DPD's `ParcelLifecycleServiceV20.wsdl` started returning **HTTP 404 with an empty body** (`https://wsshipper.dpd.nl/soap/WSDL/ParcelLifecycleServiceV20.wsdl` is a 404 right now, while e.g. `LoginServiceV20.wsdl` is fine). The empty 404 body was cached as `var/cache/prod/wsdl/527b02418d0d1c4c0eb1c427026282e7.wsdl` (`527b0241…` = `md5()` of that URL), and every parcel-status update failed from then on — long after the request itself would have succeeded.

## The change

Validate the loaded WSDL **before** writing it to the cache:

- reject an empty/whitespace-only body → `UnloadableWsdlException::noContentAt()`;
- reject content that is not a well-formed WSDL document (well-formed XML whose root element is `definitions` or `description`) → `UnloadableWsdlException::fromLocation()`.

Nothing is written on failure, so a bad upstream response is never persisted and the provider **recovers automatically** the moment the endpoint serves a valid WSDL again — no manual cache clear needed. The happy path (and the "cache hit → no reload" behaviour) is unchanged.

Note: this stops the caching of bad responses; it does not, by itself, resolve an upstream endpoint that is down (e.g. DPD's current 404) — that still needs the endpoint restored — but it removes the permanent poisoning and the manual-invalidation step.

## Testing

Adds `tests/Soap/CachedWsdlProviderTest.php`:

- valid WSDL is cached and reused without reloading;
- an empty body throws `UnloadableWsdlException` and writes no cache file;
- a malformed (HTML error page) body throws `UnloadableWsdlException` and writes no cache file.

## SemVer

**patch** — bugfix, no public API change; the happy path is unchanged and only genuinely unusable responses now raise instead of being cached.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YFpwtN4ngPyJVajzMQEmZR)_