### PR TITLE
feat: add test:flysystem console command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "doctrine/migrations": "^3.9.7",
         "doctrine/orm": "^3.6.7",
         "guzzlehttp/guzzle": "^7.13.2",
+        "league/flysystem": "^3.35.2",
         "monolog/monolog": "^3.10.0",
         "php-http/client-common": "^2.7.3",
         "php-soap/ext-soap-engine": "^1.12.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0222b856af5fc606a486b2297aafa2f4",
+    "content-hash": "c305779e976b8066e3443d28568962db",
     "packages": [],
     "packages-dev": [
         {
@@ -1458,6 +1458,194 @@
                 }
             ],
             "time": "2025-11-01T09:38:14+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "3.35.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/b277b5dc3d56650b68904117124e79c851e12376",
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem-local": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "async-aws/core": "<1.19.0",
+                "async-aws/s3": "<1.14.0",
+                "aws/aws-sdk-php": "3.209.31 || 3.210.0",
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1",
+                "phpseclib/phpseclib": "3.0.15",
+                "symfony/http-client": "<5.2"
+            },
+            "require-dev": {
+                "async-aws/s3": "^1.5 || ^2.0",
+                "async-aws/simple-s3": "^1.1 || ^2.0",
+                "aws/aws-sdk-php": "^3.295.10",
+                "composer/semver": "^3.0",
+                "ext-fileinfo": "*",
+                "ext-ftp": "*",
+                "ext-mongodb": "^1.3|^2",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.5",
+                "google/cloud-storage": "^1.23",
+                "guzzlehttp/psr7": "^2.6",
+                "microsoft/azure-storage-blob": "^1.1",
+                "mongodb/mongodb": "^1.2|^2",
+                "phpseclib/phpseclib": "^3.0.36",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.5.11|^10.0",
+                "sabre/dav": "^4.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "File storage abstraction for PHP",
+            "keywords": [
+                "WebDAV",
+                "aws",
+                "cloud",
+                "file",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/3.35.2"
+            },
+            "time": "2026-07-06T14:42:07+00:00"
+        },
+        {
+            "name": "league/flysystem-local",
+            "version": "3.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-local.git",
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/2f669db18a4c20c755c2bb7d3a7b0b2340488079",
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "league/flysystem": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\Local\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Local filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "file",
+                "files",
+                "filesystem",
+                "local"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.31.0"
+            },
+            "time": "2026-01-23T15:30:45+00:00"
+        },
+        {
+            "name": "league/mime-type-detection",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/mime-type-detection.git",
+                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "phpstan/phpstan": "^0.12.68",
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\MimeTypeDetection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Mime-type detection for Flysystem",
+            "support": {
+                "issues": "https://github.com/thephpleague/mime-type-detection/issues",
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.16.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-21T08:32:55+00:00"
         },
         {
             "name": "league/uri",
@@ -8652,5 +8840,5 @@
         "php": "~8.4.22"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Flysystem/Console/TestFlysystemCommand.php
+++ b/src/Flysystem/Console/TestFlysystemCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Etrias\PhpToolkit\Flysystem\Console;
+
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\StorageAttributes;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommand(name: 'test:flysystem')]
+final class TestFlysystemCommand extends Command
+{
+    public function __construct(
+        #[Autowire(service: 'test.storage')]
+        private readonly ?FilesystemOperator $storage = null,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $storage = $this->storage;
+        if (null === $storage) {
+            $io->error('Storage "test.storage" is not configured.');
+
+            return 1;
+        }
+
+        $file = uniqid('test_file_').'.txt';
+        $renamedFile = $file.'.renamed';
+        $contents = 'test '.time();
+
+        $io->info('Testing filesystem with file: '.$file);
+
+        $storage->write($file, $contents);
+        $io->info('Write test passed');
+
+        if ($contents !== $storage->read($file)) {
+            throw new \RuntimeException('read() returned other contents than written');
+        }
+        $io->info('Read test passed');
+
+        $files = $this->listFiles($storage);
+        $io->listing($files);
+        if (!\in_array($file, $files, true)) {
+            throw new \RuntimeException('listContents() is missing the written file');
+        }
+        $io->info('List test passed');
+
+        $storage->move($file, $renamedFile);
+        $files = $this->listFiles($storage);
+        $io->listing($files);
+        if (!\in_array($renamedFile, $files, true) || \in_array($file, $files, true)) {
+            throw new \RuntimeException('move() failed; listing does not reflect the renamed file');
+        }
+        $io->info('Rename test passed');
+
+        $storage->delete($renamedFile);
+        if ($storage->fileExists($renamedFile)) {
+            throw new \RuntimeException('delete() failed; file still exists');
+        }
+        $io->info('Delete test passed');
+
+        $io->success('All filesystem tests passed successfully.');
+
+        return 0;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function listFiles(FilesystemOperator $storage): array
+    {
+        return $storage->listContents('')
+            ->filter(static fn (StorageAttributes $attributes): bool => $attributes->isFile())
+            ->map(static fn (StorageAttributes $attributes): string => $attributes->path())
+            ->toArray()
+        ;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `test:flysystem` console command, moved from shipping-api so every consumer app can run it against its own `test.storage` Flysystem storage. It exercises write, read, list, move and delete and fails on the first mismatch.

Part of the WMS azure-libs update; companion branches: `etrias-nl/shipping-api` (removes the local command), `etrias-nl/warehouse-api` (adds `test.storage` config), `etrias-nl/kube-apps` (runs it in warehouse-api stag release tests).

## Key Changes

- `src/Flysystem/Console/TestFlysystemCommand.php`, following the existing `Cache/Console/TestAdapterCommand` pattern (`#[Autowire(service: 'test.storage')]`).
- The storage dependency is **nullable with a `null` default**: etrias cms/shop load the full toolkit `src/` but define no `test.storage` service, and a hard reference would fail their container compile on the next toolkit bump (`AutowirePass` downgrades nullable params to `NULL_ON_INVALID_REFERENCE`). Without the service the command fails at runtime instead.
- `league/flysystem` added to **require-dev** (matching how the toolkit treats all runtime deps of its optional features).

## SemVer

`feat` / minor: new command, no changes to existing code.

## Rollout order

Release this first; shipping-api's command removal and the warehouse-api/kube-apps changes must only be deployed once the apps' `etrias/php-toolkit` lock is bumped to that release (stag release tests already/will call `test:flysystem`).

https://claude.ai/code/session_013dRCjWKMA8yzLfQpbu9A6i