### PR TITLE
fix: reconnect stale DB connection in messenger consumer middleware

### DIFF
--- a/src/Messenger/Middleware/DoctrineConnectionMiddleware.php
+++ b/src/Messenger/Middleware/DoctrineConnectionMiddleware.php
@@ -39,7 +39,12 @@ final class DoctrineConnectionMiddleware implements MiddlewareInterface
         $transactional = $this->messageMap->getStamp($envelope, TransactionalStamp::class) ?? new TransactionalStamp();
 
         if (!$transactional->enabled) {
-            $this->setLimits();
+            try {
+                $this->setLimits();
+            } catch (\Exception) {
+                $this->close();
+                $this->setLimits();
+            }
 
             return $stack->next()->handle($envelope, $stack);
         }
@@ -48,8 +53,14 @@ final class DoctrineConnectionMiddleware implements MiddlewareInterface
         $entityManager = $this->managerRegistry->getManager($transactional->entityManagerName);
         $connection = $entityManager->getConnection();
 
-        $connection->beginTransaction();
-        $this->setLimits();
+        try {
+            $connection->beginTransaction();
+            $this->setLimits();
+        } catch (\Exception) {
+            $this->close();
+            $connection->beginTransaction();
+            $this->setLimits();
+        }
 
         $successful = false;
 
@@ -85,6 +96,14 @@ final class DoctrineConnectionMiddleware implements MiddlewareInterface
             ] as $query) {
                 $connection->executeQuery($query);
             }
+        }
+    }
+
+    private function close(): void
+    {
+        /** @var Connection $connection */
+        foreach ($this->managerRegistry->getConnections() as $connection) {
+            $connection->close();
         }
     }
 }


### PR DESCRIPTION
## Problem

A messenger consumer is a long-running worker. When it sits idle longer than the server-side timeout — or the connection drops via restart/failover/network — MySQL closes the connection. The next message then runs its first query on that dead connection and fails with:

```
SQLSTATE[HY000]: General error: 2006 MySQL server has gone away
(Doctrine\DBAL\Exception\ConnectionLost)
```

In `DoctrineConnectionMiddleware` that first query is `setLimits()` (`SET SESSION wait_timeout / interactive_timeout`), so the error is thrown from inside the middleware itself before the handler ever runs. Observed in `shipping-api` handling `App\Message\UpdateShippingLabelStatus`:

```
Error thrown while handling message App\Message\UpdateShippingLabelStatus.
Removing from transport after 0 retries.
Error: "... 2006 MySQL server has gone away"
```

## Why "message retry" isn't enough

The reconnect logic used to be here and was removed in `836c2d0` ("favor message retry over connection retry"), delegating recovery to a message retry on a fresh connection. That only works when the transport actually retries. For consumers whose transport disables retries — e.g. NATS with `max_retries: 0` — the `ConnectionLost` is terminal and **the message is discarded after 0 retries** (silent data loss).

## Fix

Restore the ping-and-reconnect around `setLimits()` (the same pattern that existed before `836c2d0`). `setLimits()` is itself a round-trip that throws on a dead connection, so it doubles as the ping: on failure we `close()` the connection(s) and retry, letting DBAL reconnect lazily before handling proceeds. Applied to both the non-transactional and transactional branches.

`close()` (re-added, as removed in `836c2d0`) runs **only when a query actually fails**, so the happy path never closes/reopens and connections do not stack — addressing the original reason the close was dropped.

## Impact

- Fixes lost messages on connection drop for all consumers, regardless of transport retry configuration.
- No behavioural change on the happy path (no extra close/reconnect when the connection is alive).
- No API/signature changes.

## SemVer

**`fix`** (patch) — restores previously-present resilience; no public API change.

## Context

Follow-up to etrias-nl/shipping-api#1699 and the discussion there; agreed with @ro0NL to move the fix into the toolkit so all consumers benefit. Once released, shipping-api will bump the dependency and drop its local `doctrine_ping_connection` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZXMaYvwUcTWqDdb548gGs

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZXMaYvwUcTWqDdb548gGs)_