### PR TITLE
feat: add Flysystem RuntimeAdapterFactory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,11 @@
         "php": "~8.4.23"
     },
     "require-dev": {
+        "azure-oss/storage-blob-flysystem": "^2.2.0",
         "basis-company/nats": "^1.2.1",
         "doctrine/migrations": "^3.9.7",
         "doctrine/orm": "^3.6.7",
-        "guzzlehttp/guzzle": "^8.0.0",
+        "guzzlehttp/guzzle": "^7.15.1 || ^8.0.0",
         "league/flysystem": "^3.35.2",
         "monolog/monolog": "^3.10.0",
         "php-http/client-common": "^2.7.3",

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,10 @@
         "php": "~8.4.23"
     },
     "require-dev": {
-        "azure-oss/storage-blob-flysystem": "^2.2.0",
         "basis-company/nats": "^1.2.1",
         "doctrine/migrations": "^3.9.7",
         "doctrine/orm": "^3.6.7",
-        "guzzlehttp/guzzle": "^7.15.1 || ^8.0.0",
+        "guzzlehttp/guzzle": "^8.0.0",
         "league/flysystem": "^3.35.2",
         "monolog/monolog": "^3.10.0",
         "php-http/client-common": "^2.7.3",

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,11 @@
         "php": "~8.4.23"
     },
     "require-dev": {
+        "azure-oss/storage-blob-flysystem": "^2.2.0",
         "basis-company/nats": "^1.2.1",
         "doctrine/migrations": "^3.9.7",
         "doctrine/orm": "^3.6.7",
-        "guzzlehttp/guzzle": "^8.0.0",
+        "guzzlehttp/guzzle": "^7.15.1",
         "league/flysystem": "^3.35.2",
         "monolog/monolog": "^3.10.0",
         "php-http/client-common": "^2.7.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,198 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54ee82bd153be5035ce325099d06888d",
+    "content-hash": "8318f04efc400794c9dbb2df25603395",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "azure-oss/identity",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-oss-for-azure/azure-identity-php.git",
+                "reference": "bff54412a3af6c6f7e68d36cb2d857edc338581a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-oss-for-azure/azure-identity-php/zipball/bff54412a3af6c6f7e68d36cb2d857edc338581a",
+                "reference": "bff54412a3af6c6f7e68d36cb2d857edc338581a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": "^8.1",
+                "php-http/discovery": "^1.20",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^2.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.10",
+                "laravel/pint": "^1.27",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^13.0"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Provides a PSR-18 HTTP client and PSR-17 factories (used by default when installed)."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AzureOss\\Identity\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "support": {
+                "issues": "https://github.com/Azure-OSS/azure-identity-php/issues",
+                "source": "https://github.com/Azure-OSS/azure-identity-php/tree/1.0.2"
+            },
+            "time": "2026-03-15T21:17:16+00:00"
+        },
+        {
+            "name": "azure-oss/storage-blob",
+            "version": "2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-oss-for-azure/azure-storage-blob-php.git",
+                "reference": "4c5efab53e35e734701ff81185066eaa1d43fd20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-oss-for-azure/azure-storage-blob-php/zipball/4c5efab53e35e734701ff81185066eaa1d43fd20",
+                "reference": "4c5efab53e35e734701ff81185066eaa1d43fd20",
+                "shasum": ""
+            },
+            "require": {
+                "azure-oss/storage-common": "^2.0",
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.8",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AzureOss\\Storage\\Blob\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brecht Vermeersch",
+                    "email": "brechtvermeersch@outlook.be"
+                },
+                {
+                    "name": "Pim Jansen",
+                    "email": "pimjansen@gmail.com"
+                }
+            ],
+            "description": "Azure Blob Storage PHP SDK",
+            "keywords": [
+                "azure",
+                "php",
+                "sdk",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/php-oss-for-azure/azure-storage-blob-php/tree/2.2.2"
+            },
+            "time": "2026-06-30T13:20:38+00:00"
+        },
+        {
+            "name": "azure-oss/storage-blob-flysystem",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-oss-for-azure/azure-storage-blob-flysystem-php.git",
+                "reference": "9711c530f16f6746b45edf54c419884a7d31e5b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-oss-for-azure/azure-storage-blob-flysystem-php/zipball/9711c530f16f6746b45edf54c419884a7d31e5b4",
+                "reference": "9711c530f16f6746b45edf54c419884a7d31e5b4",
+                "shasum": ""
+            },
+            "require": {
+                "azure-oss/storage-blob": "^2.2",
+                "league/flysystem": "^3.28",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AzureOss\\Storage\\BlobFlysystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brecht Vermeersch",
+                    "email": "brechtvermeersch@outlook.be"
+                },
+                {
+                    "name": "Pim Jansen",
+                    "email": "pimjansen@gmail.com"
+                }
+            ],
+            "description": "Flysystem adapter for Azure Storage PHP",
+            "support": {
+                "source": "https://github.com/Azure-OSS/azure-storage-blob-flysystem-php/tree/2.2.0"
+            },
+            "time": "2026-06-28T13:33:44+00:00"
+        },
+        {
+            "name": "azure-oss/storage-common",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-oss-for-azure/azure-storage-common-php.git",
+                "reference": "2e9c5f08bd01f5d483cfeb3b875488e677c21b78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-oss-for-azure/azure-storage-common-php/zipball/2e9c5f08bd01f5d483cfeb3b875488e677c21b78",
+                "reference": "2e9c5f08bd01f5d483cfeb3b875488e677c21b78",
+                "shasum": ""
+            },
+            "require": {
+                "azure-oss/identity": "^1.0",
+                "caseyamcl/guzzle_retry_middleware": "^2.10",
+                "guzzlehttp/guzzle": "^7.8",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AzureOss\\Storage\\Common\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brecht Vermeersch",
+                    "email": "brechtvermeersch@outlook.be"
+                }
+            ],
+            "description": "Shared primitives for Azure Storage PHP SDK packages",
+            "support": {
+                "source": "https://github.com/php-oss-for-azure/azure-storage-common-php/tree/2.1.1"
+            },
+            "time": "2026-06-30T13:20:38+00:00"
+        },
         {
             "name": "basis-company/nats",
             "version": "1.2.1",
@@ -72,6 +261,79 @@
                 "source": "https://github.com/basis-company/nats.php/tree/1.2.1"
             },
             "time": "2026-03-24T12:44:31+00:00"
+        },
+        {
+            "name": "caseyamcl/guzzle_retry_middleware",
+            "version": "v2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/caseyamcl/guzzle_retry_middleware.git",
+                "reference": "17c9299cde438b00bbeb099c6480319a81636a60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/caseyamcl/guzzle_retry_middleware/zipball/17c9299cde438b00bbeb099c6480319a81636a60",
+                "reference": "17c9299cde438b00bbeb099c6480319a81636a60",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "jaschilz/php-coverage-badger": "^2.0",
+                "nesbot/carbon": "^2.0|^3.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.0",
+                "phpunit/phpunit": "^7.5|^8.0|^9.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/var-dumper": "^5.0|^6.0|^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleRetry\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Casey McLaughlin",
+                    "email": "caseyamcl@gmail.com",
+                    "homepage": "https://caseymclaughlin.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Guzzle v6+ retry middleware that handles 429/503 status codes and connection timeouts",
+            "homepage": "https://github.com/caseyamcl/guzzle_retry_middleware",
+            "keywords": [
+                "Guzzle",
+                "back-off",
+                "caseyamcl",
+                "guzzle_retry_middleware",
+                "middleware",
+                "retry",
+                "retry-after"
+            ],
+            "support": {
+                "issues": "https://github.com/caseyamcl/guzzle_retry_middleware/issues",
+                "source": "https://github.com/caseyamcl/guzzle_retry_middleware/tree/v2.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/caseyamcl",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-11T12:33:22+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -1067,27 +1329,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "8.0.0",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "643356760d8efce521dfce2587d63fd9d0c70d72"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/643356760d8efce521dfce2587d63fd9d0c70d72",
-                "reference": "643356760d8efce521dfce2587d63fd9d0c70d72",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^3.0",
-                "guzzlehttp/psr7": "^3.0",
-                "php": "^7.4 || ^8.0",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.13",
+                "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0",
-                "symfony/polyfill-php80": "^1.25",
-                "symfony/polyfill-php82": "^1.27"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1095,10 +1356,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "4.0.1",
-                "guzzlehttp/test-server": "^1.0@dev",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^9.6.34",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1114,6 +1375,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
                 }
@@ -1173,7 +1437,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/8.0.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -1189,28 +1453,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-20T13:53:10+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "3.0.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "d961a21387cd680ec1cc6f52aa1fdcef33105e24"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/d961a21387cd680ec1cc6f52aa1fdcef33105e24",
-                "reference": "d961a21387cd680ec1cc6f52aa1fdcef33105e24",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^9.6.34"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1256,7 +1521,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/3.0.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -1272,39 +1537,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-20T13:44:17+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "3.0.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
-                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0",
-                "psr/http-factory": "^1.1",
-                "psr/http-message": "^2.0",
-                "symfony/polyfill-php80": "^1.25",
-                "symfony/polyfill-php82": "^1.27"
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
-                "psr/http-factory-implementation": "1.1",
-                "psr/http-message-implementation": "2.0"
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "php-http/psr7-integration-tests": "^1.5.1",
-                "phpunit/phpunit": "^9.6.34"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1375,7 +1640,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/3.0.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -1391,7 +1656,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-20T13:48:31+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "laminas/laminas-code",
@@ -5321,6 +5586,50 @@
             "time": "2024-09-11T13:17:53+00:00"
         },
         {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
             "name": "revolt/event-loop",
             "version": "v1.0.9",
             "source": {
@@ -8793,5 +9102,5 @@
         "php": "~8.4.23"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,198 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54ee82bd153be5035ce325099d06888d",
+    "content-hash": "03ab492306e2199a2c8347109ceb3526",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "azure-oss/identity",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-oss-for-azure/azure-identity-php.git",
+                "reference": "bff54412a3af6c6f7e68d36cb2d857edc338581a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-oss-for-azure/azure-identity-php/zipball/bff54412a3af6c6f7e68d36cb2d857edc338581a",
+                "reference": "bff54412a3af6c6f7e68d36cb2d857edc338581a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": "^8.1",
+                "php-http/discovery": "^1.20",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^2.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.10",
+                "laravel/pint": "^1.27",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^13.0"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Provides a PSR-18 HTTP client and PSR-17 factories (used by default when installed)."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AzureOss\\Identity\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "support": {
+                "issues": "https://github.com/Azure-OSS/azure-identity-php/issues",
+                "source": "https://github.com/Azure-OSS/azure-identity-php/tree/1.0.2"
+            },
+            "time": "2026-03-15T21:17:16+00:00"
+        },
+        {
+            "name": "azure-oss/storage-blob",
+            "version": "2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-oss-for-azure/azure-storage-blob-php.git",
+                "reference": "4c5efab53e35e734701ff81185066eaa1d43fd20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-oss-for-azure/azure-storage-blob-php/zipball/4c5efab53e35e734701ff81185066eaa1d43fd20",
+                "reference": "4c5efab53e35e734701ff81185066eaa1d43fd20",
+                "shasum": ""
+            },
+            "require": {
+                "azure-oss/storage-common": "^2.0",
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.8",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AzureOss\\Storage\\Blob\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brecht Vermeersch",
+                    "email": "brechtvermeersch@outlook.be"
+                },
+                {
+                    "name": "Pim Jansen",
+                    "email": "pimjansen@gmail.com"
+                }
+            ],
+            "description": "Azure Blob Storage PHP SDK",
+            "keywords": [
+                "azure",
+                "php",
+                "sdk",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/php-oss-for-azure/azure-storage-blob-php/tree/2.2.2"
+            },
+            "time": "2026-06-30T13:20:38+00:00"
+        },
+        {
+            "name": "azure-oss/storage-blob-flysystem",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-oss-for-azure/azure-storage-blob-flysystem-php.git",
+                "reference": "9711c530f16f6746b45edf54c419884a7d31e5b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-oss-for-azure/azure-storage-blob-flysystem-php/zipball/9711c530f16f6746b45edf54c419884a7d31e5b4",
+                "reference": "9711c530f16f6746b45edf54c419884a7d31e5b4",
+                "shasum": ""
+            },
+            "require": {
+                "azure-oss/storage-blob": "^2.2",
+                "league/flysystem": "^3.28",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AzureOss\\Storage\\BlobFlysystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brecht Vermeersch",
+                    "email": "brechtvermeersch@outlook.be"
+                },
+                {
+                    "name": "Pim Jansen",
+                    "email": "pimjansen@gmail.com"
+                }
+            ],
+            "description": "Flysystem adapter for Azure Storage PHP",
+            "support": {
+                "source": "https://github.com/Azure-OSS/azure-storage-blob-flysystem-php/tree/2.2.0"
+            },
+            "time": "2026-06-28T13:33:44+00:00"
+        },
+        {
+            "name": "azure-oss/storage-common",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-oss-for-azure/azure-storage-common-php.git",
+                "reference": "2e9c5f08bd01f5d483cfeb3b875488e677c21b78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-oss-for-azure/azure-storage-common-php/zipball/2e9c5f08bd01f5d483cfeb3b875488e677c21b78",
+                "reference": "2e9c5f08bd01f5d483cfeb3b875488e677c21b78",
+                "shasum": ""
+            },
+            "require": {
+                "azure-oss/identity": "^1.0",
+                "caseyamcl/guzzle_retry_middleware": "^2.10",
+                "guzzlehttp/guzzle": "^7.8",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AzureOss\\Storage\\Common\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brecht Vermeersch",
+                    "email": "brechtvermeersch@outlook.be"
+                }
+            ],
+            "description": "Shared primitives for Azure Storage PHP SDK packages",
+            "support": {
+                "source": "https://github.com/php-oss-for-azure/azure-storage-common-php/tree/2.1.1"
+            },
+            "time": "2026-06-30T13:20:38+00:00"
+        },
         {
             "name": "basis-company/nats",
             "version": "1.2.1",
@@ -72,6 +261,79 @@
                 "source": "https://github.com/basis-company/nats.php/tree/1.2.1"
             },
             "time": "2026-03-24T12:44:31+00:00"
+        },
+        {
+            "name": "caseyamcl/guzzle_retry_middleware",
+            "version": "v2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/caseyamcl/guzzle_retry_middleware.git",
+                "reference": "17c9299cde438b00bbeb099c6480319a81636a60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/caseyamcl/guzzle_retry_middleware/zipball/17c9299cde438b00bbeb099c6480319a81636a60",
+                "reference": "17c9299cde438b00bbeb099c6480319a81636a60",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "jaschilz/php-coverage-badger": "^2.0",
+                "nesbot/carbon": "^2.0|^3.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.0",
+                "phpunit/phpunit": "^7.5|^8.0|^9.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/var-dumper": "^5.0|^6.0|^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleRetry\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Casey McLaughlin",
+                    "email": "caseyamcl@gmail.com",
+                    "homepage": "https://caseymclaughlin.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Guzzle v6+ retry middleware that handles 429/503 status codes and connection timeouts",
+            "homepage": "https://github.com/caseyamcl/guzzle_retry_middleware",
+            "keywords": [
+                "Guzzle",
+                "back-off",
+                "caseyamcl",
+                "guzzle_retry_middleware",
+                "middleware",
+                "retry",
+                "retry-after"
+            ],
+            "support": {
+                "issues": "https://github.com/caseyamcl/guzzle_retry_middleware/issues",
+                "source": "https://github.com/caseyamcl/guzzle_retry_middleware/tree/v2.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/caseyamcl",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-11T12:33:22+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -1067,27 +1329,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "8.0.0",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "643356760d8efce521dfce2587d63fd9d0c70d72"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/643356760d8efce521dfce2587d63fd9d0c70d72",
-                "reference": "643356760d8efce521dfce2587d63fd9d0c70d72",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^3.0",
-                "guzzlehttp/psr7": "^3.0",
-                "php": "^7.4 || ^8.0",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.13",
+                "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0",
-                "symfony/polyfill-php80": "^1.25",
-                "symfony/polyfill-php82": "^1.27"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1095,10 +1356,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "4.0.1",
-                "guzzlehttp/test-server": "^1.0@dev",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^9.6.34",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1114,6 +1375,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
                 }
@@ -1173,7 +1437,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/8.0.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -1189,28 +1453,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-20T13:53:10+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "3.0.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "d961a21387cd680ec1cc6f52aa1fdcef33105e24"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/d961a21387cd680ec1cc6f52aa1fdcef33105e24",
-                "reference": "d961a21387cd680ec1cc6f52aa1fdcef33105e24",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^9.6.34"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1256,7 +1521,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/3.0.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -1272,39 +1537,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-20T13:44:17+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "3.0.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
-                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0",
-                "psr/http-factory": "^1.1",
-                "psr/http-message": "^2.0",
-                "symfony/polyfill-php80": "^1.25",
-                "symfony/polyfill-php82": "^1.27"
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
-                "psr/http-factory-implementation": "1.1",
-                "psr/http-message-implementation": "2.0"
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "php-http/psr7-integration-tests": "^1.5.1",
-                "phpunit/phpunit": "^9.6.34"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1375,7 +1640,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/3.0.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -1391,7 +1656,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-20T13:48:31+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "laminas/laminas-code",
@@ -5321,6 +5586,50 @@
             "time": "2024-09-11T13:17:53+00:00"
         },
         {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
             "name": "revolt/event-loop",
             "version": "v1.0.9",
             "source": {
@@ -8793,5 +9102,5 @@
         "php": "~8.4.23"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,198 +4,9 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03ab492306e2199a2c8347109ceb3526",
+    "content-hash": "54ee82bd153be5035ce325099d06888d",
     "packages": [],
     "packages-dev": [
-        {
-            "name": "azure-oss/identity",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-oss-for-azure/azure-identity-php.git",
-                "reference": "bff54412a3af6c6f7e68d36cb2d857edc338581a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-oss-for-azure/azure-identity-php/zipball/bff54412a3af6c6f7e68d36cb2d857edc338581a",
-                "reference": "bff54412a3af6c6f7e68d36cb2d857edc338581a",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "php": "^8.1",
-                "php-http/discovery": "^1.20",
-                "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^2.0"
-            },
-            "require-dev": {
-                "guzzlehttp/guzzle": "^7.10",
-                "laravel/pint": "^1.27",
-                "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-deprecation-rules": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^13.0"
-            },
-            "suggest": {
-                "guzzlehttp/guzzle": "Provides a PSR-18 HTTP client and PSR-17 factories (used by default when installed)."
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AzureOss\\Identity\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "support": {
-                "issues": "https://github.com/Azure-OSS/azure-identity-php/issues",
-                "source": "https://github.com/Azure-OSS/azure-identity-php/tree/1.0.2"
-            },
-            "time": "2026-03-15T21:17:16+00:00"
-        },
-        {
-            "name": "azure-oss/storage-blob",
-            "version": "2.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-oss-for-azure/azure-storage-blob-php.git",
-                "reference": "4c5efab53e35e734701ff81185066eaa1d43fd20"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-oss-for-azure/azure-storage-blob-php/zipball/4c5efab53e35e734701ff81185066eaa1d43fd20",
-                "reference": "4c5efab53e35e734701ff81185066eaa1d43fd20",
-                "shasum": ""
-            },
-            "require": {
-                "azure-oss/storage-common": "^2.0",
-                "ext-curl": "*",
-                "ext-json": "*",
-                "ext-simplexml": "*",
-                "guzzlehttp/guzzle": "^7.8",
-                "php": "^8.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AzureOss\\Storage\\Blob\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Brecht Vermeersch",
-                    "email": "brechtvermeersch@outlook.be"
-                },
-                {
-                    "name": "Pim Jansen",
-                    "email": "pimjansen@gmail.com"
-                }
-            ],
-            "description": "Azure Blob Storage PHP SDK",
-            "keywords": [
-                "azure",
-                "php",
-                "sdk",
-                "storage"
-            ],
-            "support": {
-                "source": "https://github.com/php-oss-for-azure/azure-storage-blob-php/tree/2.2.2"
-            },
-            "time": "2026-06-30T13:20:38+00:00"
-        },
-        {
-            "name": "azure-oss/storage-blob-flysystem",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-oss-for-azure/azure-storage-blob-flysystem-php.git",
-                "reference": "9711c530f16f6746b45edf54c419884a7d31e5b4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-oss-for-azure/azure-storage-blob-flysystem-php/zipball/9711c530f16f6746b45edf54c419884a7d31e5b4",
-                "reference": "9711c530f16f6746b45edf54c419884a7d31e5b4",
-                "shasum": ""
-            },
-            "require": {
-                "azure-oss/storage-blob": "^2.2",
-                "league/flysystem": "^3.28",
-                "php": "^8.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AzureOss\\Storage\\BlobFlysystem\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Brecht Vermeersch",
-                    "email": "brechtvermeersch@outlook.be"
-                },
-                {
-                    "name": "Pim Jansen",
-                    "email": "pimjansen@gmail.com"
-                }
-            ],
-            "description": "Flysystem adapter for Azure Storage PHP",
-            "support": {
-                "source": "https://github.com/Azure-OSS/azure-storage-blob-flysystem-php/tree/2.2.0"
-            },
-            "time": "2026-06-28T13:33:44+00:00"
-        },
-        {
-            "name": "azure-oss/storage-common",
-            "version": "2.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-oss-for-azure/azure-storage-common-php.git",
-                "reference": "2e9c5f08bd01f5d483cfeb3b875488e677c21b78"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-oss-for-azure/azure-storage-common-php/zipball/2e9c5f08bd01f5d483cfeb3b875488e677c21b78",
-                "reference": "2e9c5f08bd01f5d483cfeb3b875488e677c21b78",
-                "shasum": ""
-            },
-            "require": {
-                "azure-oss/identity": "^1.0",
-                "caseyamcl/guzzle_retry_middleware": "^2.10",
-                "guzzlehttp/guzzle": "^7.8",
-                "php": "^8.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AzureOss\\Storage\\Common\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Brecht Vermeersch",
-                    "email": "brechtvermeersch@outlook.be"
-                }
-            ],
-            "description": "Shared primitives for Azure Storage PHP SDK packages",
-            "support": {
-                "source": "https://github.com/php-oss-for-azure/azure-storage-common-php/tree/2.1.1"
-            },
-            "time": "2026-06-30T13:20:38+00:00"
-        },
         {
             "name": "basis-company/nats",
             "version": "1.2.1",
@@ -261,79 +72,6 @@
                 "source": "https://github.com/basis-company/nats.php/tree/1.2.1"
             },
             "time": "2026-03-24T12:44:31+00:00"
-        },
-        {
-            "name": "caseyamcl/guzzle_retry_middleware",
-            "version": "v2.13.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/caseyamcl/guzzle_retry_middleware.git",
-                "reference": "17c9299cde438b00bbeb099c6480319a81636a60"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/caseyamcl/guzzle_retry_middleware/zipball/17c9299cde438b00bbeb099c6480319a81636a60",
-                "reference": "17c9299cde438b00bbeb099c6480319a81636a60",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/guzzle": "^6.3|^7.0",
-                "php": "^7.1|^8.0"
-            },
-            "require-dev": {
-                "jaschilz/php-coverage-badger": "^2.0",
-                "nesbot/carbon": "^2.0|^3.0",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.0",
-                "phpunit/phpunit": "^7.5|^8.0|^9.0",
-                "squizlabs/php_codesniffer": "^3.5",
-                "symfony/var-dumper": "^5.0|^6.0|^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleRetry\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Casey McLaughlin",
-                    "email": "caseyamcl@gmail.com",
-                    "homepage": "https://caseymclaughlin.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Guzzle v6+ retry middleware that handles 429/503 status codes and connection timeouts",
-            "homepage": "https://github.com/caseyamcl/guzzle_retry_middleware",
-            "keywords": [
-                "Guzzle",
-                "back-off",
-                "caseyamcl",
-                "guzzle_retry_middleware",
-                "middleware",
-                "retry",
-                "retry-after"
-            ],
-            "support": {
-                "issues": "https://github.com/caseyamcl/guzzle_retry_middleware/issues",
-                "source": "https://github.com/caseyamcl/guzzle_retry_middleware/tree/v2.13.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/caseyamcl",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-07-11T12:33:22+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -1329,26 +1067,27 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "643356760d8efce521dfce2587d63fd9d0c70d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/643356760d8efce521dfce2587d63fd9d0c70d72",
+                "reference": "643356760d8efce521dfce2587d63fd9d0c70d72",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5.1",
-                "guzzlehttp/psr7": "^2.13",
-                "php": "^7.2.5 || ^8.0",
+                "guzzlehttp/promises": "^3.0",
+                "guzzlehttp/psr7": "^3.0",
+                "php": "^7.4 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.25"
+                "psr/http-factory": "^1.0",
+                "symfony/polyfill-php80": "^1.25",
+                "symfony/polyfill-php82": "^1.27"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1356,10 +1095,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.3",
-                "guzzlehttp/test-server": "^0.7",
+                "guzzle/client-integration-tests": "4.0.1",
+                "guzzlehttp/test-server": "^1.0@dev",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
+                "phpunit/phpunit": "^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1375,9 +1114,6 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
                 }
@@ -1437,7 +1173,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/8.0.0"
             },
             "funding": [
                 {
@@ -1453,29 +1189,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-20T13:53:10+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
+                "reference": "d961a21387cd680ec1cc6f52aa1fdcef33105e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/d961a21387cd680ec1cc6f52aa1fdcef33105e24",
+                "reference": "d961a21387cd680ec1cc6f52aa1fdcef33105e24",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0",
-                "symfony/deprecation-contracts": "^2.5 || ^3.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+                "phpunit/phpunit": "^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1521,7 +1256,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.1"
+                "source": "https://github.com/guzzle/promises/tree/3.0.0"
             },
             "funding": [
                 {
@@ -1537,39 +1272,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T15:48:39+00:00"
+            "time": "2026-07-20T13:44:17+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.13.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
+                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
-                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
+                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0",
-                "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.25"
+                "php": "^7.4 || ^8.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^2.0",
+                "symfony/polyfill-php80": "^1.25",
+                "symfony/polyfill-php82": "^1.27"
             },
             "provide": {
-                "psr/http-factory-implementation": "1.0",
-                "psr/http-message-implementation": "1.0"
+                "psr/http-factory-implementation": "1.1",
+                "psr/http-message-implementation": "2.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+                "php-http/psr7-integration-tests": "^1.5.1",
+                "phpunit/phpunit": "^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1640,7 +1375,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
+                "source": "https://github.com/guzzle/psr7/tree/3.0.0"
             },
             "funding": [
                 {
@@ -1656,7 +1391,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-16T22:23:49+00:00"
+            "time": "2026-07-20T13:48:31+00:00"
         },
         {
             "name": "laminas/laminas-code",
@@ -5584,50 +5319,6 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
-            "name": "ralouphie/getallheaders",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^5 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/getallheaders.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ralph Khattar",
-                    "email": "ralph.khattar@gmail.com"
-                }
-            ],
-            "description": "A polyfill for getallheaders.",
-            "support": {
-                "issues": "https://github.com/ralouphie/getallheaders/issues",
-                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
-            },
-            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "revolt/event-loop",

--- a/composer.lock
+++ b/composer.lock
@@ -9102,5 +9102,5 @@
         "php": "~8.4.23"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,6 +5,33 @@
       <code><![CDATA[$event->getError()]]></code>
     </InvalidArgument>
   </file>
+  <file src="src/Flysystem/RuntimeAdapterFactory.php">
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$urlParts['host']]]></code>
+      <code><![CDATA[$urlParts['pass']]]></code>
+      <code><![CDATA[$urlParts['path']]]></code>
+      <code><![CDATA[$urlParts['scheme']]]></code>
+      <code><![CDATA[$urlParts['user']]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyInvalidArrayAssignment>
+      <code><![CDATA[$urlParts['pass']]]></code>
+      <code><![CDATA[$urlParts['scheme']]]></code>
+      <code><![CDATA[$urlParts['user']]]></code>
+    </PossiblyInvalidArrayAssignment>
+    <PossiblyNullArgument>
+      <code><![CDATA[$urlParts['host']]]></code>
+      <code><![CDATA[$urlParts['pass']]]></code>
+      <code><![CDATA[$urlParts['path']]]></code>
+      <code><![CDATA[$urlParts['user']]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$urlParts['host']]]></code>
+      <code><![CDATA[$urlParts['pass']]]></code>
+      <code><![CDATA[$urlParts['path']]]></code>
+      <code><![CDATA[$urlParts['scheme']]]></code>
+      <code><![CDATA[$urlParts['user']]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
   <file src="src/Http/LoggerPlugin.php">
     <DeprecatedMethod>
       <code><![CDATA[formatResponse]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -31,6 +31,13 @@
       <code><![CDATA[$urlParts['scheme']]]></code>
       <code><![CDATA[$urlParts['user']]]></code>
     </PossiblyUndefinedArrayOffset>
+    <UndefinedClass>
+      <code><![CDATA[BlobServiceClient]]></code>
+    </UndefinedClass>
+    <UnusedVariable>
+      <code><![CDATA[$connectionString]]></code>
+      <code><![CDATA[$directory]]></code>
+    </UnusedVariable>
   </file>
   <file src="src/Http/LoggerPlugin.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -31,13 +31,6 @@
       <code><![CDATA[$urlParts['scheme']]]></code>
       <code><![CDATA[$urlParts['user']]]></code>
     </PossiblyUndefinedArrayOffset>
-    <UndefinedClass>
-      <code><![CDATA[BlobServiceClient]]></code>
-    </UndefinedClass>
-    <UnusedVariable>
-      <code><![CDATA[$connectionString]]></code>
-      <code><![CDATA[$directory]]></code>
-    </UnusedVariable>
   </file>
   <file src="src/Http/LoggerPlugin.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,33 +5,6 @@
       <code><![CDATA[$event->getError()]]></code>
     </InvalidArgument>
   </file>
-  <file src="src/Flysystem/RuntimeAdapterFactory.php">
-    <PossiblyInvalidArrayAccess>
-      <code><![CDATA[$urlParts['host']]]></code>
-      <code><![CDATA[$urlParts['pass']]]></code>
-      <code><![CDATA[$urlParts['path']]]></code>
-      <code><![CDATA[$urlParts['scheme']]]></code>
-      <code><![CDATA[$urlParts['user']]]></code>
-    </PossiblyInvalidArrayAccess>
-    <PossiblyInvalidArrayAssignment>
-      <code><![CDATA[$urlParts['pass']]]></code>
-      <code><![CDATA[$urlParts['scheme']]]></code>
-      <code><![CDATA[$urlParts['user']]]></code>
-    </PossiblyInvalidArrayAssignment>
-    <PossiblyNullArgument>
-      <code><![CDATA[$urlParts['host']]]></code>
-      <code><![CDATA[$urlParts['pass']]]></code>
-      <code><![CDATA[$urlParts['path']]]></code>
-      <code><![CDATA[$urlParts['user']]]></code>
-    </PossiblyNullArgument>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$urlParts['host']]]></code>
-      <code><![CDATA[$urlParts['pass']]]></code>
-      <code><![CDATA[$urlParts['path']]]></code>
-      <code><![CDATA[$urlParts['scheme']]]></code>
-      <code><![CDATA[$urlParts['user']]]></code>
-    </PossiblyUndefinedArrayOffset>
-  </file>
   <file src="src/Http/LoggerPlugin.php">
     <DeprecatedMethod>
       <code><![CDATA[formatResponse]]></code>

--- a/src/Flysystem/RuntimeAdapterFactory.php
+++ b/src/Flysystem/RuntimeAdapterFactory.php
@@ -19,22 +19,27 @@ final class RuntimeAdapterFactory
         }
 
         $urlParts = parse_url($dsn);
+        if (false === $urlParts) {
+            throw new \RuntimeException('Unable to parse filesystem DSN');
+        }
+
         $queryParts = [];
         parse_str($urlParts['query'] ?? '', $queryParts);
-        $protocol = $urlParts['scheme'];
-        $urlParts['scheme'] = filter_var($queryParts['ssl'] ?? true, FILTER_VALIDATE_BOOLEAN) ? 'https' : 'http';
-        $urlParts['user'] = urldecode($urlParts['user']);
-        $urlParts['pass'] = urldecode($urlParts['pass']);
-        $directory = urldecode(ltrim($urlParts['path'], '/'));
+        $protocol = $urlParts['scheme'] ?? '';
+        $scheme = filter_var($queryParts['ssl'] ?? true, FILTER_VALIDATE_BOOLEAN) ? 'https' : 'http';
+        $user = urldecode($urlParts['user'] ?? '');
+        $pass = urldecode($urlParts['pass'] ?? '');
+        $host = $urlParts['host'] ?? '';
+        $directory = urldecode(ltrim($urlParts['path'] ?? '', '/'));
 
         switch ($protocol) {
             case self::TYPE_AZURE_BLOB:
-                $connectionString = \sprintf('DefaultEndpointsProtocol=%s;AccountName=%s;AccountKey=%s;EndpointSuffix=%s', $urlParts['scheme'], $urlParts['user'], $urlParts['pass'], $urlParts['host']);
+                $connectionString = \sprintf('DefaultEndpointsProtocol=%s;AccountName=%s;AccountKey=%s;EndpointSuffix=%s', $scheme, $user, $pass, $host);
                 $blobServiceClient = BlobServiceClient::fromConnectionString($connectionString);
 
                 return new AzureBlobStorageAdapter($blobServiceClient->getContainerClient($directory), $prefix);
         }
 
-        throw new \RuntimeException('Unsupported filesystem DSN protocol: '.$urlParts['scheme']);
+        throw new \RuntimeException('Unsupported filesystem DSN protocol: '.$protocol);
     }
 }

--- a/src/Flysystem/RuntimeAdapterFactory.php
+++ b/src/Flysystem/RuntimeAdapterFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Etrias\PhpToolkit\Flysystem;
+
+use AzureOss\Storage\Blob\BlobServiceClient;
+use AzureOss\Storage\BlobFlysystem\AzureBlobStorageAdapter;
+use League\Flysystem\FilesystemAdapter;
+
+final class RuntimeAdapterFactory
+{
+    private const string TYPE_AZURE_BLOB = 'azure+blob';
+
+    public static function create(string $dsn, FilesystemAdapter $default, string $prefix = ''): FilesystemAdapter
+    {
+        if (false === filter_var($dsn, FILTER_VALIDATE_URL)) {
+            return $default;
+        }
+
+        $urlParts = parse_url($dsn);
+        $queryParts = [];
+        parse_str($urlParts['query'] ?? '', $queryParts);
+        $protocol = $urlParts['scheme'];
+        $urlParts['scheme'] = filter_var($queryParts['ssl'] ?? true, FILTER_VALIDATE_BOOLEAN) ? 'https' : 'http';
+        $urlParts['user'] = urldecode($urlParts['user']);
+        $urlParts['pass'] = urldecode($urlParts['pass']);
+        $directory = urldecode(ltrim($urlParts['path'], '/'));
+
+        switch ($protocol) {
+            case self::TYPE_AZURE_BLOB:
+                $connectionString = \sprintf('DefaultEndpointsProtocol=%s;AccountName=%s;AccountKey=%s;EndpointSuffix=%s', $urlParts['scheme'], $urlParts['user'], $urlParts['pass'], $urlParts['host']);
+                $blobServiceClient = BlobServiceClient::fromConnectionString($connectionString);
+
+                return new AzureBlobStorageAdapter($blobServiceClient->getContainerClient($directory), $prefix);
+        }
+
+        throw new \RuntimeException('Unsupported filesystem DSN protocol: '.$urlParts['scheme']);
+    }
+}


### PR DESCRIPTION
Moves `App\Flysystem\RuntimeAdapterFactory` from shipping-api into the toolkit as `Etrias\PhpToolkit\Flysystem\RuntimeAdapterFactory`, so both etrias and shipping-api can share the runtime DSN-override adapter (`azure+blob://` support) used for `test.storage` and the connector storages.

**SemVer**: `feat` (minor) — new class; dev-only dependency changes.

Dependency notes (require-dev only):
- `azure-oss/storage-blob-flysystem: ^2.2.0` added so psalm resolves the AzureOss classes.
- `guzzlehttp/guzzle` pinned to `^7.15.1`: azure-oss requires guzzle `^7.8` in every released version, and all consumer projects (etrias, shipping-api, warehouse-api) are still on guzzle 7 anyway.

Follow-ups after release: shipping-api and warehouse-api `claude/etrias-php84-flysystem-3gd5w7` switch their config to this class, and etrias uses it for the new `test.storage` definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VupwA97iVvk15qUcG9kC9b