### PR TITLE
feat: restart the worker when a service inside the cluster is unreachable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/doctrine-bridge": "^7.4.14",
         "symfony/doctrine-messenger": "^7.4.14",
         "symfony/event-dispatcher": "^7.4.14",
+        "symfony/http-client-contracts": "^3.6.0",
         "symfony/http-foundation": "^7.4.14",
         "symfony/lock": "^7.4.14",
         "symfony/messenger": "^7.4.14",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/doctrine-bridge": "^7.4.14",
         "symfony/doctrine-messenger": "^7.4.14",
         "symfony/event-dispatcher": "^7.4.14",
-        "symfony/http-client-contracts": "^3.6.0",
+        "symfony/http-client-contracts": "^3.7.1",
         "symfony/http-foundation": "^7.4.14",
         "symfony/lock": "^7.4.14",
         "symfony/messenger": "^7.4.14",

--- a/composer.lock
+++ b/composer.lock
@@ -6800,6 +6800,88 @@
             "time": "2026-05-29T05:06:50+00:00"
         },
         {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/41fc42d276aeff21192465331ebbab7d83a743c0",
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
             "name": "symfony/http-foundation",
             "version": "v7.4.14",
             "source": {
@@ -9102,5 +9184,5 @@
         "php": "~8.4.23"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36a1c31c3fff94f5174231a4380081d6",
+    "content-hash": "9b8452156b28d330f406a7a9eed9f01d",
     "packages": [],
     "packages-dev": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b8452156b28d330f406a7a9eed9f01d",
+    "content-hash": "86d8874b0fd4c09ea632614f252f0626",
     "packages": [],
     "packages-dev": [
         {
@@ -9184,5 +9184,5 @@
         "php": "~8.4.23"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Messenger/EventListener/RejectDelayListener.php
+++ b/src/Messenger/EventListener/RejectDelayListener.php
@@ -12,6 +12,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 final class RejectDelayListener implements EventSubscriberInterface
 {
@@ -43,7 +44,7 @@ final class RejectDelayListener implements EventSubscriberInterface
             }
         }
 
-        if ($exception instanceof NetworkExceptionInterface) {
+        if ($exception instanceof NetworkExceptionInterface || $exception instanceof TransportExceptionInterface) {
             return self::DEFAULT_WAIT_MS;
         }
 

--- a/src/Messenger/EventListener/WorkerBackoffListener.php
+++ b/src/Messenger/EventListener/WorkerBackoffListener.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Etrias\PhpToolkit\Messenger\EventListener;
+
+use Doctrine\DBAL\Exception\ConnectionException;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * RejectDelayListener already delays the failed message itself, but the worker picks up the next
+ * one immediately. While a service is unreachable that turns into hundreds of connection attempts
+ * per second, all of them doomed. This pauses the worker instead, longer with every failure in a row.
+ */
+final class WorkerBackoffListener implements EventSubscriberInterface
+{
+    private const int START_MS = 250;
+    private const int MAX_MS = 30_000;
+    private const int MAX_SHIFT = 20;
+
+    private int $failures = 0;
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function onMessageFailed(WorkerMessageFailedEvent $event): void
+    {
+        if (!$this->isConnectivityFailure($event->getThrowable())) {
+            return;
+        }
+
+        ++$this->failures;
+    }
+
+    public function onMessageHandled(WorkerMessageHandledEvent $event): void
+    {
+        if ($this->failures > 0) {
+            $this->logger->notice('Worker resumed after {failures} connectivity failures', [
+                'failures' => $this->failures,
+                'receiver' => $event->getReceiverName(),
+            ]);
+        }
+
+        $this->failures = 0;
+    }
+
+    public function onWorkerRunning(WorkerRunningEvent $event): void
+    {
+        if (0 === $this->failures) {
+            return;
+        }
+
+        $delayMs = min(self::MAX_MS, self::START_MS << min($this->failures - 1, self::MAX_SHIFT));
+        // Without jitter every worker backs off in lockstep and they all hit the failing service again
+        // at the same moment, which is the spike we are trying to get rid of.
+        $delayMs = random_int(intdiv($delayMs, 2), $delayMs);
+
+        if (1 === $this->failures) {
+            $this->logger->notice('Worker backing off after a connectivity failure', ['delay_ms' => $delayMs]);
+        }
+
+        usleep($delayMs * 1000);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageFailedEvent::class => 'onMessageFailed',
+            WorkerMessageHandledEvent::class => 'onMessageHandled',
+            WorkerRunningEvent::class => 'onWorkerRunning',
+        ];
+    }
+
+    private function isConnectivityFailure(\Throwable $exception): bool
+    {
+        if ($exception instanceof HandlerFailedException) {
+            foreach ($exception->getWrappedExceptions(null, true) as $wrappedException) {
+                if ($this->isConnectivityFailure($wrappedException)) {
+                    return true;
+                }
+            }
+        }
+
+        if ($exception instanceof NetworkExceptionInterface
+            || $exception instanceof TransportExceptionInterface
+            || $exception instanceof ConnectionException
+        ) {
+            return true;
+        }
+
+        $previousException = $exception->getPrevious();
+
+        return null !== $previousException && $this->isConnectivityFailure($previousException);
+    }
+}

--- a/src/Messenger/EventListener/WorkerBackoffListener.php
+++ b/src/Messenger/EventListener/WorkerBackoffListener.php
@@ -12,28 +12,37 @@ use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 /**
- * RejectDelayListener already delays the failed message itself, but the worker picks up the next
- * one immediately. While a service is unreachable that turns into hundreds of connection attempts
- * per second, all of them doomed. This pauses the worker instead, longer with every failure in a row.
+ * Losing a service inside the cluster usually means a stale connection or stale DNS, and the worker
+ * cannot fix either by trying harder — it keeps taking messages that all fail the same way. A short
+ * backoff rides out a blip; anything longer exits the worker, so Kubernetes restarts the pod on a
+ * fresh connection and paces further attempts through its own restart backoff.
+ *
+ * Services outside the cluster are left alone: restarting does not bring them back, and taking every
+ * worker down because one carrier is unreachable costs more than it saves. RejectDelayListener
+ * delays those messages instead.
  */
 final class WorkerBackoffListener implements EventSubscriberInterface
 {
     private const int START_MS = 250;
-    private const int MAX_MS = 30_000;
-    private const int MAX_SHIFT = 20;
+    private const int MAX_FAILURES = 5;
 
     private int $failures = 0;
 
+    /**
+     * @param list<string> $internalHostMarkers substrings that mark a request host as cluster-internal;
+     *                                          the default is the Kubernetes service DNS shape
+     *                                          `<service>.<namespace>.svc.<cluster-domain>`
+     */
     public function __construct(
         private readonly LoggerInterface $logger,
+        private readonly array $internalHostMarkers = ['.svc.'],
     ) {}
 
     public function onMessageFailed(WorkerMessageFailedEvent $event): void
     {
-        if (!$this->isConnectivityFailure($event->getThrowable())) {
+        if (!$this->isInternalConnectivityFailure($event->getThrowable())) {
             return;
         }
 
@@ -42,13 +51,6 @@ final class WorkerBackoffListener implements EventSubscriberInterface
 
     public function onMessageHandled(WorkerMessageHandledEvent $event): void
     {
-        if ($this->failures > 0) {
-            $this->logger->notice('Worker resumed after {failures} connectivity failures', [
-                'failures' => $this->failures,
-                'receiver' => $event->getReceiverName(),
-            ]);
-        }
-
         $this->failures = 0;
     }
 
@@ -58,16 +60,18 @@ final class WorkerBackoffListener implements EventSubscriberInterface
             return;
         }
 
-        $delayMs = min(self::MAX_MS, self::START_MS << min($this->failures - 1, self::MAX_SHIFT));
-        // Without jitter every worker backs off in lockstep and they all hit the failing service again
-        // at the same moment, which is the spike we are trying to get rid of.
-        $delayMs = random_int(intdiv($delayMs, 2), $delayMs);
+        if ($this->failures >= self::MAX_FAILURES) {
+            $this->logger->critical('Stopping the worker after {failures} failures to reach a service inside the cluster', [
+                'failures' => $this->failures,
+            ]);
 
-        if (1 === $this->failures) {
-            $this->logger->notice('Worker backing off after a connectivity failure', ['delay_ms' => $delayMs]);
+            throw new \RuntimeException(sprintf('Unable to reach a service inside the cluster, giving up after %d consecutive failures.', $this->failures));
         }
 
-        usleep($delayMs * 1000);
+        $delayMs = self::START_MS << ($this->failures - 1);
+        // Without jitter every worker backs off in lockstep and they all hit the failing service again
+        // at the same moment, which is the spike we are trying to get rid of.
+        usleep(random_int(intdiv($delayMs, 2), $delayMs) * 1000);
     }
 
     public static function getSubscribedEvents(): array
@@ -79,25 +83,37 @@ final class WorkerBackoffListener implements EventSubscriberInterface
         ];
     }
 
-    private function isConnectivityFailure(\Throwable $exception): bool
+    private function isInternalConnectivityFailure(\Throwable $exception): bool
     {
         if ($exception instanceof HandlerFailedException) {
             foreach ($exception->getWrappedExceptions(null, true) as $wrappedException) {
-                if ($this->isConnectivityFailure($wrappedException)) {
+                if ($this->isInternalConnectivityFailure($wrappedException)) {
                     return true;
                 }
             }
         }
 
-        if ($exception instanceof NetworkExceptionInterface
-            || $exception instanceof TransportExceptionInterface
-            || $exception instanceof ConnectionException
-        ) {
+        if ($exception instanceof ConnectionException) {
+            return true;
+        }
+
+        if ($exception instanceof NetworkExceptionInterface && $this->isInternalHost($exception->getRequest()->getUri()->getHost())) {
             return true;
         }
 
         $previousException = $exception->getPrevious();
 
-        return null !== $previousException && $this->isConnectivityFailure($previousException);
+        return null !== $previousException && $this->isInternalConnectivityFailure($previousException);
+    }
+
+    private function isInternalHost(string $host): bool
+    {
+        foreach ($this->internalHostMarkers as $internalHostMarker) {
+            if (str_contains($host, $internalHostMarker)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
Splits connectivity failures by where the service lives, following review on the first version of this PR.

- **Inside the cluster** (Solr, MySQL): back off briefly, then exit the worker. Kubernetes restarts the pod on a fresh connection and paces further attempts through its own restart backoff.
- **Outside the cluster** (carriers, PSPs): nothing changes for the worker. `RejectDelayListener` delays those messages — restarting our pod does not bring their service back, and taking every worker down because one carrier is unreachable costs more than it saves.

## The problem
`RejectDelayListener` delays the **failed message** (`RejectDelayStamp`, `NatsTransport::reject()` NAKs it, default 5 minutes). It does not delay the **worker**, which takes the next message immediately. With a backlog of tens of thousands of messages and Solr down, that is hundreds of connection attempts per second, all doomed, and a returning wave five minutes later.

Retrying harder cannot fix a stale connection or stale DNS. Restarting can, and where it cannot, Kubernetes' restart backoff is a better rate limiter than anything we would write here.

## `WorkerBackoffListener`
Counts consecutive cluster-internal connectivity failures, resets on the first success:

- failures 1–4: sleep 250ms, 500ms, 1s, 2s (jittered, so workers do not resume in lockstep) — enough to ride out a GC pause or a rolling restart
- failure 5: log `critical` and throw, so `messenger:consume` exits non-zero and the pod restarts

## Classifying internal vs external
- `Doctrine\DBAL\Exception\ConnectionException` — always internal
- `Psr\Http\Client\NetworkExceptionInterface` — the failed request's host is matched against `internalHostMarkers`, default `['.svc.']`, the Kubernetes service DNS shape `<service>.<namespace>.svc.<cluster-domain>`. Production Solr is `solr-solrcloud-common.solr.svc.etrias-production.k8s-bizhost.nl.`, so it matches; a local `solr.` does not, which keeps dev containers from restarting themselves.

`Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface` carries no request, so it cannot be classified and is treated as external.

NATS is not handled here: `NatsTransport` throws `TransportException` from `get()`, which is not caught in `Worker::run()`, so a receive failure already exits the worker.

## Also in this PR
`RejectDelayListener` now recognises `TransportExceptionInterface` next to `NetworkExceptionInterface` — Symfony HttpClient transport errors were falling through and getting no delay at all. `symfony/http-client-contracts` is added to `require-dev` for it.

## Only in worker pods
All three events are dispatched exclusively by `Symfony\Component\Messenger\Worker`, which runs only under `messenger:consume`. The sync transport handles messages inline without going through `Worker`, so no web request ever sleeps or exits here.

## SemVer
**Minor (`feat:`)** — new subscriber; no behavioural change while nothing is failing.