### PR TITLE
fix: skip undecodable messages in NatsTransport instead of crash-looping

### DIFF
--- a/src/Messenger/Transport/NatsTransport.php
+++ b/src/Messenger/Transport/NatsTransport.php
@@ -128,7 +128,32 @@ final class NatsTransport implements TransportInterface, MessageCountAwareInterf
                 $stamps[] = new ReplyToStamp($replyTo, $this->getMessageExpiresAt());
             }
 
-            return [$this->serializer->decode(['body' => $payload->body])->with(...$stamps)];
+            try {
+                $envelope = $this->serializer->decode(['body' => $payload->body]);
+            } catch (\Throwable $e) {
+                // Undecodable ("poison") message: a stale signature, a changed
+                // serialization format or a corrupt body. It can never be decoded,
+                // so terminate it — stopping JetStream redelivering it — and skip.
+                // Without this the decode failure rethrows, crashes the consumer and
+                // the same message is re-read on restart, crash-looping forever and
+                // stalling the transport.
+                if (null !== $replyTo = $message->replyTo) {
+                    try {
+                        self::assertPayload($this->client->dispatch($replyTo, '+TERM'));
+                    } catch (\Throwable $termException) {
+                        $this->log(Level::Error, null, new TransportException($termException->getMessage(), 0, $termException));
+                    }
+                }
+
+                $this->log(Level::Error, null, 'Discarded undecodable message: {error}', [
+                    'error' => $e->getMessage(),
+                    'exception' => $e,
+                ]);
+
+                return [];
+            }
+
+            return [$envelope->with(...$stamps)];
         } catch (\Throwable $e) {
             $this->unsubscribe();
 


### PR DESCRIPTION
## Problem

`NatsTransport::get()` reads from two sources — the Doctrine **fallback** transport first (`fallbackTransport->all(1)` / `->get()`), then the **NATS** queue (`serializer->decode(...)`) — inside one broad `try { … } catch (\Throwable) { unsubscribe(); throw new TransportException(...); }`.

When a message can **never** be decoded — a missing/invalid signature (`InvalidMessageSignatureException`), a changed serialization format (e.g. an `ErrorException` while `unserialize()`-ing a class whose shape changed, such as `RunProcessMessage::$commandLine`), or a corrupt body — the failure is rethrown as a `TransportException`. Symfony's worker treats that as a transport-level failure, so `messenger:consume` exits, Kubernetes restarts it, the same **poison message** is re-read, and the consumer **crash-loops indefinitely** — stalling the transport and blocking any deploy whose worker readiness depends on it.

The fallback path makes it worse: `all(1)` only *peeks* the first message to compare timestamps, so a poison row in the Doctrine fallback table is re-read on **every** `get()` and **never removed** — the loop cannot self-heal even in principle.

### Observed in production

A rolling deploy left pre-signing / old-format `Symfony\Component\Process\Messenger\RunProcessMessage` messages parked in the **Doctrine fallback** transport (`messenger_fallback`) of the `scheduled_command` worker. The new consumer couldn't decode them (`InvalidMessageSignatureException: … requires a signature but none was found`, plus a `RunProcessMessage::$commandLine` dynamic-property deprecation) and crash-looped, holding the ArgoCD sync from going healthy. Purging the NATS stream did nothing — the poison was in the Doctrine fallback table.

## Fix

Make both read paths resilient to poison messages:

1. **NATS decode** — isolate `serializer->decode()`; on failure `+TERM` the message (so JetStream stops redelivering it) and skip it.
2. **Doctrine fallback read** — wrap `all(1)` / `get()`; on failure log and fall through to the NATS queue instead of letting the decode failure escape `get()`.

Both log at error level **with the exception** in context. Transient transport/connection errors still surface as `TransportException` and retry exactly as before — only genuine, non-recoverable *decode* failures are handled.

## SemVer

**patch (`fix:`)** — resilience fix, no public API change.

## Notes

- The fallback guard prevents the crash but does not itself delete the poison row from the Doctrine fallback table (`all(1)` can't identify the row without decoding it). During the incident that row must still be cleared out of band (`DELETE FROM messenger_fallback WHERE queue_name = 'scheduled_command'`); after this fix a future occurrence degrades to a logged skip instead of a crash-loop.
- No new tests added (out of scope for this hotfix); happy to add coverage for the poison-message paths on request.